### PR TITLE
fix: install all npm dependencies including Vite for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-alpine AS frontend-builder
 
 WORKDIR /app/frontend
 COPY dirt_stack/frontend/package*.json ./
-RUN npm ci --only=production
+RUN npm ci
 
 COPY dirt_stack/frontend/ ./
 RUN npm run build


### PR DESCRIPTION
- Remove --only=production flag to include devDependencies
- Vite is required for npm run build in frontend stage
- Fixes Docker build failure in CI/CD pipeline