### PR TITLE
fix: add media file serving for images in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ COPY dirt_stack/backend/ ./
 # Fix ALLOWED_HOSTS for container deployment
 RUN sed -i "s/ALLOWED_HOSTS = \[.*\]/ALLOWED_HOSTS = ['*']/" dirt_project/settings.py
 
+# Copy media files
+COPY dirt_stack/backend/media ./media/
+
 # Copy frontend build from previous stage
 COPY --from=frontend-builder /app/frontend/dist ../frontend/dist/
 

--- a/dirt_stack/backend/dirt_project/urls.py
+++ b/dirt_stack/backend/dirt_project/urls.py
@@ -11,6 +11,5 @@ urlpatterns = [
     path('', include('pages.urls')),
 ]
 
-# Serve media files during development
-if settings.DEBUG:
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# Serve media files (including production for Docker)
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
- Copy media files to Docker container
- Enable media file serving in production Django URLs
- Fixes missing background images in deployed application